### PR TITLE
PHPコンテナを動かす

### DIFF
--- a/app/server/index.php
+++ b/app/server/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "Hello World! Goodbye World!";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,21 @@ services:
     volumes:
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./app/server:/var/www/html
+    networks:
+      - app_network
+
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/app/Dockerfile
+    container_name: t-app
+    volumes:
+      - ./app/server:/var/www/html
+    depends_on:
+      - nginx
+    networks:
+      - app_network
+
+networks:
+  app_network:
+    driver: bridge

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.1-fpm
+
+COPY ./docker/app/php.ini /usr/local/etc/php/
+
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y zlib1g-dev \ 
+    libzip-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libmagickwand-dev --no-install-recommends \
+    zip \
+    unzip
+
+WORKDIR /var/www

--- a/docker/app/php.ini
+++ b/docker/app/php.ini
@@ -1,0 +1,7 @@
+[Date]
+date.timezone = "Asia/Tokyo"
+[mbstring]
+mbstring.internal_encoding = "UTF-8"
+mbstring.language = "Japanese"
+
+memory_limit = 256M

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -2,5 +2,18 @@ server {
   listen 80;
     index index.php index.html;
     root /var/www/html;
- }
- 
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app:9000; # docker-compose service nameを指定
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+  }
+}


### PR DESCRIPTION
## GOAL
http://localhost:80 へアクセスすると `app/server/index.php` のecho文字列が出力される
<img width="618" alt="result-01" src="https://github.com/sachiokuwahata/trial-architecture/assets/46374808/db4b2f26-3f5a-4185-b135-75f1f062202e">


## Point

1. nginxに来たphp関連のリクエストをapp:9000コンテナへリクエスト

`fastcgi_pass app:9000`　で設定することで、appへリクエストします。

https://github.com/sachiokuwahata/trial-architecture/blob/896a9d585c52cc53aca3de3015306f41832abae4/docker/nginx/default.conf#L13

`app/server` 配下には、
- index.php
- index.html
の２ファイルが存在する。
index.php側のファイルが読み込まれているのは、[docker/nginx/default.conf](docker/nginx/default.conf)の設定で、index.phpを優先しているため。
これを逆にしたり、index.phpのファイル名を変更すると、index.htmlが読み込まれる。

