### PR TITLE
nextjsからLaravelのAPIサーバーに対してリクエスト・レスポンスを成功させる

### DIFF
--- a/app/front/.env.local
+++ b/app/front/.env.local
@@ -1,0 +1,2 @@
+NODE_ENV=local
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080/api

--- a/app/front/.gitignore
+++ b/app/front/.gitignore
@@ -26,7 +26,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+# .env*.local
 
 # vercel
 .vercel

--- a/app/front/app/page.tsx
+++ b/app/front/app/page.tsx
@@ -1,7 +1,21 @@
+"use client";
 import Image from "next/image";
 import styles from "./page.module.css";
+import { useEffect } from "react";
+import { server } from '@/next.config.mjs';
 
 export default function Home() {
+  useEffect(() => {
+    console.log("Hello, world!");
+    async function fetchHealthCheck() {
+      const response = await fetch(`${server}/health`);
+      const data = await response.json();
+      console.log(data);
+    }
+
+    fetchHealthCheck();
+  }, []);
+
   return (
     <main className={styles.main}>
       <div className={styles.description}>

--- a/app/front/next.config.mjs
+++ b/app/front/next.config.mjs
@@ -2,3 +2,6 @@
 const nextConfig = {};
 
 export default nextConfig;
+
+const dev = process.env.NODE_ENV !== 'production';
+export const server = dev ? `${process.env.NEXT_PUBLIC_API_BASE_URL}` : 'https://production-domain.com/api';

--- a/app/server/routes/api.php
+++ b/app/server/routes/api.php
@@ -17,3 +17,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/health', function () {
+    return response()->json(['status' => 'OK']);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: ./docker/nginx/Dockerfile
     container_name: t-nginx
     ports:
-      - 80:80
+      - 8080:80
     volumes:
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./app/server:/var/www/src
@@ -58,7 +58,7 @@ services:
     volumes:
       - ./app/front:/app/front
     ports:
-      - 3000:3000
+      - 80:3000
     tty: true # コンテナの正常終了を防ぐ
     networks:
       - app_network


### PR DESCRIPTION
## GOAL
nextjsからLaravelのAPIサーバーに対してリクエスト・レスポンスを成功させる

<img width="1512" alt="result-01" src="https://github.com/sachiokuwahata/trial-architecture/assets/46374808/9f5ae299-ede0-4068-89b3-b592beba256b">

## Points

nextjsからのAPIリクエスト先にnginxコンテナを指定する

https://github.com/sachiokuwahata/trial-architecture/commit/cf86013be7b7e0bdb631ef9f8d0d0701022d0f7d
https://github.com/sachiokuwahata/trial-architecture/commit/924b453d536e6c277652d316584691ba469b5e55



